### PR TITLE
Consumed the `.` when parsing

### DIFF
--- a/Fluent.Net/RuntimeParser.cs
+++ b/Fluent.Net/RuntimeParser.cs
@@ -807,6 +807,7 @@ namespace Fluent.Net
             if (Current == '.')
             {
                 num.Append('.');
+                Next();
 
                 // followed by at least one digit
                 if (Current < '0' || Current > '9')


### PR DESCRIPTION
There was a problem parsing follwing messsage from the fluent samples
```
your-score =
    { NUMBER($score, minimumFractionDigits: 1) ->
        [0.0]   You scored zero points. What happened?
       *[other] You scored { NUMBER($score, minimumFractionDigits: 1) } points.
    }
```

The `.` if `[0.0]` was not consumed while parsing. this resulted in an error since a digit was expected and not another dot.